### PR TITLE
Update buttons, links, and other clickables

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -44,19 +44,19 @@ codes:
 buttons:
     - name: "Get Started"
       primary: true
-      url: "#"
+      url: "#" # TODO: put link to Arkouda Demo here
     - name: "Documentation"
-      url: "#"
+      url: "https://bears-r-us.github.io/arkouda/"
     - name: "Chat on Gitter"
       icon: "message-square"
-      url: "#"
+      url: "https://gitter.im/ArkoudaProject/community"
 
 announcement:
-    title: "Arkouda 3.2.6 released!"
+    title: "Arkouda v2024.04.19 released!"
     content: |
-      The new release brings the `addOne` message, which significantly speeds up increment operations on large arrays!
+      The new release brings optimized Parquet `Strings` reads, which significantly speeds up  operations on data in `.parquet` files, along with more Array API functionality!
 
-      [Read the release notes →](#)
+      [Read the release notes →](https://github.com/Bears-R-Us/arkouda/releases/tag/v2024.04.19)
 ---
 
 ## Arkouda is...
@@ -67,33 +67,33 @@ announcement:
 ### Fast
 Arkouda is powered by [Chapel](https://chapel-lang.org), a programming language built from the ground up to support parallelism and distributed computing. Make the most out of every core and every node in your arsenal.
 
-[See performance results →](#)
+<!-- [See performance results →](#) -->
 {{< /rect >}}
 
 {{< rect >}}
 ### Interactive
 By distributing your data across multiple nodes, Arkouda allows you to rapidly transform and wrangle datasets in real time that are simply intractable for a laptop or desktop.
 
-[Read about Arkouda in Jupyter →](#)
+<!-- [Read about Arkouda in Jupyter →](#) -->
 {{< /rect >}}
 
 {{< rect >}}
 ### Familiar
 Arkouda's library functions deliberately mirror those of NumPy and Pandas, so you can get started with minimal learning curve.
 
-[Compare to NumPy and Dask →](#)
+<!-- [Compare to NumPy and Dask →](#) -->
 {{< /rect >}}
 
 {{< /rectlist >}}
 
 ## Arkouda users are saying...
 
-{{< quote author="Daniel Fedorin" affiliation="Hewlett Packard Enterprise" url="#" >}}
-Arkouda is my favorite breakfast meal! It's very filling and nutritious.
+{{< quote author="Scott Bachman" affiliation="NCAR" url="https://ncar.ucar.edu/" >}}
+[Arkouda] represents a paradigm shift in the way biodiversity can be measured at scale.
 {{< /quote >}}
 
-{{< quote author="Alinad Nerodef" affiliation="Airline Pilot" url="#" >}}
-I used to be afraid of bears, but the Arkouda logo convinced me to finally buy one. I'm one happy customer!
+{{< quote author="Jake Trookman" affiliation="Erias" url="#" >}}
+[I'm] working with more data than I ever thought possible as a data scientist!
 {{< /quote >}}
 
 ## With Arkouda, you can...

--- a/content/_index.md
+++ b/content/_index.md
@@ -88,11 +88,11 @@ Arkouda's library functions deliberately mirror those of NumPy and Pandas, so yo
 
 ## Arkouda users are saying...
 
-{{< quote author="Scott Bachman" affiliation="NCAR" url="https://ncar.ucar.edu/" >}}
-[Arkouda] represents a paradigm shift in the way biodiversity can be measured at scale.
+{{< quote author="Tess Hayes" affiliation="Bytoa" url="" >}}
+…solving problems in a matter of seconds, as opposed to days…
 {{< /quote >}}
 
-{{< quote author="Jake Trookman" affiliation="Erias" url="#" >}}
+{{< quote author="Jake Trookman" affiliation="Erias" url="" >}}
 [I'm] working with more data than I ever thought possible as a data scientist!
 {{< /quote >}}
 

--- a/hugo.toml
+++ b/hugo.toml
@@ -18,20 +18,20 @@ name = 'Gitter'
 url = 'https://gitter.im/ArkoudaProject/community'
 weight = 30
 
-[[menus.main]]
-name = 'Discourse'
-url = '#'
-weight = 40
+# [[menus.main]]
+# name = 'Discourse'
+# url = '#'
+# weight = 40
 
-[[menus.main]]
-name = 'Community'
-url = '#'
-weight = 50
+# [[menus.main]]
+# name = 'Community'
+# url = '#'
+# weight = 50
 
-[[menus.main]]
-name = 'About'
-url = '/about'
-weight = 60
+# [[menus.main]]
+# name = 'About'
+# url = '/about'
+# weight = 60
 
 [markup.goldmark.renderer]
 unsafe= true

--- a/themes/arkouda/assets/scss/main.scss
+++ b/themes/arkouda/assets/scss/main.scss
@@ -112,8 +112,7 @@ section:not(section section) {
             border-color: var(--primary-color);
         }
     }
-
-    .sample-wrapper {
+    .sample-wrapper-div {
         flex-basis: 0;
         flex-grow: 1;
 
@@ -126,11 +125,19 @@ section:not(section section) {
             border-left: 0.075rem solid grey;
         }
     }
+    .sample-wrapper {
+        max-width: 14rem; // Might need to be adjusted if text
+        cursor: pointer;
+
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        justify-content: center;
+    }
 
     .sample {
         display: flex;
         flex-direction: column;
-        cursor: pointer;
 
         .name {
             font-weight: bold;

--- a/themes/arkouda/layouts/_default/home.html
+++ b/themes/arkouda/layouts/_default/home.html
@@ -14,11 +14,13 @@
     <div class="code-example" id="first-comparison">
       <fieldset>
         {{ range .Params.codes }}
-          <div class="sample-wrapper">
-            <input type="radio" id="radio-{{ .name }}" value="{{ .name }}" name="code-sample" {{ if eq .name "Arkouda" }}checked{{ end }}></inpt>
-            <label class="sample" for="radio-{{ .name }}">
-              <span class="name">{{ .name }}</span>
-              <span class="description">{{ .title }}</span>
+          <div class="sample-wrapper-div">
+            <label class="sample-wrapper" for="radio-{{ .name }}">
+              <input type="radio" id="radio-{{ .name }}" value="{{ .name }}" name="code-sample" {{ if eq .name "Arkouda" }}checked{{ end }}>
+              <span class="sample">
+                <span class="name">{{ .name }}</span>
+                <span class="description">{{ .title }}</span>
+              </span>
             </label>
           </div>
         {{ end }}


### PR DESCRIPTION
This PR does the following:
- Put real quotes in from Arkouda Users
- Make sure all the buttons go somewhere
  - Fix "Chat on Gitter" and "Documentation" buttons in main body
  - Remove Discourse, community, and about buttons from top nav bar. This is content that is planned but not ready
  - Comment out following buttons from the "Arkouda is ... fast ..." section
    - See performance results
    - Read about Arkouda in Jupyter
    - Compare to Numpy and Dask
  - we want to have content that those go to, but we don't yet.
- Pending link for "Getting Started" demo.
- Update the Announcement to be the last release for Arkouda (v2024.04.19)
- Make clicking the radio buttons easier by expanding the clickable area to be more than just the text to include the empty space between the text and radio button and also some extra space around them
